### PR TITLE
Best practices, round 1

### DIFF
--- a/vt.py
+++ b/vt.py
@@ -62,15 +62,13 @@ class VirusTotal:
             2. Creates output file
             3. Gives url to
         '''
-        analysis = open(self.analysis_file, 'a')
-        ifile = open(input_filename, 'r')
-        domainList = ifile.read().split()
+        with open(input_filename, 'r') as ifile:
+            domainList = ifile.read().split()
 
-        for i in range(0, len(domainList)):
-            result = self.request(domainList[i])
-            self.analysis.write(str(result))
-        ifile.close()
-        analysis.close()
+        with open(self.analysis_file, 'a') as analysis:
+            for i in range(0, len(domainList)):
+                result = self.request(domainList[i])
+                analysis.write(str(result))
         return
 
     def inspect_to_csv(self, input_filename):

--- a/vt.py
+++ b/vt.py
@@ -55,6 +55,21 @@ class VirusTotal:
             d = f.read.splitlines()
         return d
 
+    @staticmethod
+    def _domains_from_file(i):
+        """Extract list of domains from input file
+
+        Args:
+            ifile (file): file with list of domains to assess
+
+        Returns:
+            list: list of domains extracted from file
+        """
+
+        with open(ifile, 'r') as f:
+            d = f.read.split()
+        return d
+
     def inspect(self, input_filename):
         '''
             Driver.
@@ -62,8 +77,7 @@ class VirusTotal:
             2. Creates output file
             3. Gives url to
         '''
-        with open(input_filename, 'r') as ifile:
-            domainList = ifile.read().split()
+        domainList = self._domains_from_file(input_file)
 
         with open(self.analysis_file, 'a') as analysis:
             for i in range(0, len(domainList)):

--- a/vt.py
+++ b/vt.py
@@ -85,7 +85,7 @@ class VirusTotal:
                 analysis.write(str(result))
         return
 
-    def inspect_to_csv(self, input_filename):
+    def inspect_to_csv(self, input_filename):  # Consider using Pandas for this
         '''
             Driver.
             1. Reads domain list from file
@@ -198,7 +198,7 @@ class VirusTotal:
 
         return
 
-    def csv_output(self, result):
+    def csv_output(self, result):  # Again, either use Pandas or python's CSV
         analysis = open(self.analysis_file, 'a')
         domain = result['url']
         row = domain + ","


### PR DESCRIPTION
There's a lot here that we can improve on, but I'll take a stab at one obvious problem that was pretty pervasive: using `open()` instead of `with open()`.

You pretty much always want to use `with open()` when handling files to ensure that they get close gracefully. Otherwise it's much harder to assure that if an exception or fault is encountered, the FD will close.

Changes:
 - Remove trailing whitespace
 - Change from basic logger to using a simple logger (let the user setup their own, you pass things up to theirs)
   - This will come into play later when we package this. We shouldn't run it directly.
 - Add private helper method `_domains_from_file()` to replace the repeated process of opening and consuming the domains file.
 - Declare `_get_avs` as a static method. Methods that do not take advantage of `self` should get the `@staticmethod` decorator.
 - Parameterize `VirusTotal` class. You can now initialize the class and pass arguments into it.
 - Explanatory comments on Try/Except/Pass and using Pandas or CSV to generate/process CSVs